### PR TITLE
Fixes #16064 - Settings are not loading correctly for capsules

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_client.rb
@@ -1,11 +1,12 @@
 require 'net/http'
 require 'net/https'
 require 'uri'
+require 'smart_proxy_pulp_plugin/settings'
 
 module PulpProxy
   class PulpClient
     def self.get(path)
-      uri = URI.parse(::PulpProxy::Plugin.settings.pulp_url.to_s)
+      uri = URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s)
       path = [uri.path, path].join('/') unless uri.path.empty?
       req = Net::HTTP::Get.new(URI.join(uri.to_s, path).path)
       req.add_field('Accept', 'application/json')
@@ -14,7 +15,7 @@ module PulpProxy
     end
 
     def self.http
-      uri = URI.parse(::PulpProxy::Plugin.settings.pulp_url.to_s)
+      uri = URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/smart_proxy_pulp_plugin/pulp_node_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_node_plugin.rb
@@ -1,4 +1,4 @@
-module PulpMasterProxy
+module PulpNodeProxy
   class Plugin < ::Proxy::Plugin
     plugin "pulpnode", ::PulpProxy::VERSION
     default_settings :pulp_url => 'https://localhost/pulp',

--- a/lib/smart_proxy_pulp_plugin/settings.rb
+++ b/lib/smart_proxy_pulp_plugin/settings.rb
@@ -1,0 +1,12 @@
+require 'sinatra'
+require 'smart_proxy_pulp_plugin/pulp_node_plugin'
+require 'smart_proxy_pulp_plugin/pulp_plugin'
+
+module PulpProxy
+  class Settings 
+    def self.settings 
+      # work around until pulp node settings are no longer needed by foreman proxy, as pulp nodes have been removed
+      ::PulpProxy::Plugin.settings.pulp_url ? ::PulpProxy::Plugin.settings : ::PulpNodeProxy::Plugin.settings
+    end
+  end
+end

--- a/test/pulp_api_test.rb
+++ b/test/pulp_api_test.rb
@@ -47,6 +47,17 @@ class PulpApiTest < Test::Unit::TestCase
     assert_equal(%w(filesystem 1k-blocks used available percent mounted path size).to_set, response['pulp_dir'].keys.to_set)
   end
 
+  def test_use_default_pulp_node_settings_200
+    PulpNodeProxy::Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
+                                             :pulp_content_dir => ::Sinatra::Application.settings.root,
+                                             :mongodb_dir => ::Sinatra::Application.settings.root)
+
+    PulpProxy::Plugin.settings = nil
+    stub_request(:get, "#{::PulpNodeProxy::Plugin.settings.pulp_url.to_s}/api/v2/status/").to_return(:body => "{\"api_version\":\"2\"}")
+    get '/status'
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+  end
+
   def test_change_pulp_disk_size
     PulpProxy::Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
                                          :pulp_content_dir => ::Sinatra::Application.settings.root,


### PR DESCRIPTION
Pulp node settings are not loading properly on a capsule. This will
use pulp settings as a fallback, and may help to remove pulp node
settings from foreman proxy as pulp nodes have been removed from
capsules.