### PR TITLE
Prevent // in the pulp URL

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_api.rb
@@ -10,7 +10,7 @@ module PulpProxy
     get "/status" do
       content_type :json
       begin
-        result = PulpClient.get("/api/v2/status/")
+        result = PulpClient.get("api/v2/status/")
         return result.body if result.is_a?(Net::HTTPSuccess)
         log_halt result.code, "Pulp server at #{::PulpProxy::Settings.settings.pulp_url} returned an error: '#{result.message}'"
       rescue Errno::ECONNREFUSED => e

--- a/lib/smart_proxy_pulp_plugin/pulp_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_client.rb
@@ -7,8 +7,7 @@ module PulpProxy
   class PulpClient
     def self.get(path)
       uri = URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s)
-      path = [uri.path, path].join('/') unless uri.path.empty?
-      req = Net::HTTP::Get.new(URI.join(uri.to_s, path).path)
+      req = Net::HTTP::Get.new(URI.join(uri.to_s.chomp('/') + '/', path).path)
       req.add_field('Accept', 'application/json')
       req.content_type = 'application/json'
       response = self.http.request(req)

--- a/test/pulp_client_test.rb
+++ b/test/pulp_client_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'webmock/test_unit'
+require 'mocha/test_unit'
+
+require 'smart_proxy_pulp_plugin/pulp_plugin'
+require 'smart_proxy_pulp_plugin/pulp_client'
+
+class PulpClientTest < Test::Unit::TestCase
+  def test_get_status_with_trailing_slash
+    PulpProxy::Plugin.load_test_settings('pulp_url' => 'http://localhost/pulp/')
+    stub_request(:get, "http://localhost/pulp/api/v2/status/")
+
+    result = PulpProxy::PulpClient.get("api/v2/status/")
+    assert result.is_a?(Net::HTTPSuccess)
+  end
+
+  def test_get_status_without_trailing_slash
+    PulpProxy::Plugin.load_test_settings('pulp_url' => 'http://localhost/pulp')
+    stub_request(:get, "http://localhost/pulp/api/v2/status/")
+
+    result = PulpProxy::PulpClient.get("api/v2/status/")
+    assert result.is_a?(Net::HTTPSuccess)
+  end
+end


### PR DESCRIPTION
This triggered a test failure on Ruby 2.5. Looks like previously it was
normalized.