### PR TITLE
Fixes #25547 - added authorization to status calls

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_api.rb
@@ -6,6 +6,8 @@ require 'smart_proxy_pulp_plugin/settings'
 module PulpProxy
   class Api < Sinatra::Base
     helpers ::Proxy::Helpers
+    authorize_with_trusted_hosts
+    authorize_with_ssl_client
 
     get "/status" do
       content_type :json


### PR DESCRIPTION
This looks like a good idea to me, this endpoint is only used by Foreman server anyway which uses SSL client certificate and it's also in trusted hosts entries.