### PR TITLE
Add pulp 3 support exposing capabilities and settings

### DIFF
--- a/lib/smart_proxy_pulp.rb
+++ b/lib/smart_proxy_pulp.rb
@@ -2,4 +2,3 @@ require 'smart_proxy_pulp_plugin/version'
 require 'smart_proxy_pulp_plugin/pulp_plugin'
 require 'smart_proxy_pulp_plugin/pulp_node_plugin'
 require 'smart_proxy_pulp_plugin/pulp3_plugin'
-

--- a/lib/smart_proxy_pulp.rb
+++ b/lib/smart_proxy_pulp.rb
@@ -1,3 +1,5 @@
 require 'smart_proxy_pulp_plugin/version'
 require 'smart_proxy_pulp_plugin/pulp_plugin'
 require 'smart_proxy_pulp_plugin/pulp_node_plugin'
+require 'smart_proxy_pulp_plugin/pulp3_plugin'
+

--- a/lib/smart_proxy_pulp_plugin/disk_usage.rb
+++ b/lib/smart_proxy_pulp_plugin/disk_usage.rb
@@ -2,7 +2,7 @@ module PulpProxy
   class DiskUsage
     include ::Proxy::Util
     include ::Proxy::Log
-    SIZE = { :kilobyte => 1_024, :megabyte => 1_048_576, :gigabyte => 1_073_741_824, :terabyte => 1_099_511_627_776 }
+    SIZE = { :byte => 1, :kilobyte => 1_024, :megabyte => 1_048_576, :gigabyte => 1_073_741_824, :terabyte => 1_099_511_627_776 }
 
     attr_reader :path, :stat, :size
 

--- a/lib/smart_proxy_pulp_plugin/pulp3_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_api.rb
@@ -1,0 +1,33 @@
+require 'sinatra'
+require 'smart_proxy_pulp_plugin/pulp3_client'
+require 'smart_proxy_pulp_plugin/disk_usage'
+
+module PulpProxy
+  class Pulp3Api < Sinatra::Base
+    helpers ::Proxy::Helpers
+
+    get "/status" do
+      content_type :json
+      begin
+        result = Pulp3Client.get("api/v3/status/")
+        return result.body if result.is_a?(Net::HTTPSuccess)
+        log_halt result.code, "Pulp server at #{::PulpProxy::Settings.settings.pulp_url} returned an error: '#{result.message}'"
+      rescue Errno::ECONNREFUSED => e
+        log_halt 503, "Pulp server at #{::PulpProxy::Settings.settings.pulp_url} is not responding"
+      rescue SocketError => e
+        log_halt 503, "Pulp server '#{URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s).host}' is unknown"
+      end
+    end
+
+    get '/status/disk_usage' do
+      size = (params[:size] && DiskUsage::SIZE.keys.include?(params[:size].to_sym)) ? params[:size].to_sym : :byte
+      monitor_dirs = Hash[::PulpProxy::Pulp3Plugin.settings.marshal_dump.select { |key, _| key == :pulp_dir || key == :pulp_content_dir || key == :mongodb_dir }]
+      begin
+        pulp_disk = DiskUsage.new({:path => monitor_dirs, :size => size})
+        pulp_disk.to_json
+      rescue ::Proxy::Error::ConfigurationError
+        log_halt 500, 'Could not find df command to evaluate disk space'
+      end
+    end
+  end
+end

--- a/lib/smart_proxy_pulp_plugin/pulp3_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_api.rb
@@ -21,7 +21,7 @@ module PulpProxy
 
     get '/status/disk_usage' do
       size = (params[:size] && DiskUsage::SIZE.keys.include?(params[:size].to_sym)) ? params[:size].to_sym : :byte
-      monitor_dirs = Hash[::PulpProxy::Pulp3Plugin.settings.marshal_dump.select { |key, _| key == :pulp_dir || key == :pulp_content_dir || key == :mongodb_dir }]
+      monitor_dirs = Hash[::PulpProxy::Pulp3Plugin.settings.marshal_dump.select { |key, _| key == :pulp_dir || key == :pulp_content_dir }]
       begin
         pulp_disk = DiskUsage.new({:path => monitor_dirs, :size => size})
         pulp_disk.to_json

--- a/lib/smart_proxy_pulp_plugin/pulp3_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_api.rb
@@ -6,24 +6,29 @@ module PulpProxy
   class Pulp3Api < Sinatra::Base
     helpers ::Proxy::Helpers
 
-    get "/status" do
+    get '/status' do
       content_type :json
       begin
         result = Pulp3Client.get("api/v3/status/")
         return result.body if result.is_a?(Net::HTTPSuccess)
         log_halt result.code, "Pulp server at #{::PulpProxy::Settings.settings.pulp_url} returned an error: '#{result.message}'"
-      rescue Errno::ECONNREFUSED => e
-        log_halt 503, "Pulp server at #{::PulpProxy::Settings.settings.pulp_url} is not responding"
-      rescue SocketError => e
-        log_halt 503, "Pulp server '#{URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s).host}' is unknown"
+      rescue SocketError, Errno::ECONNREFUSED => e
+        log_halt 503, "Communication error with '#{URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s).host}': #{e.message}"
       end
     end
 
     get '/status/disk_usage' do
-      size = (params[:size] && DiskUsage::SIZE.keys.include?(params[:size].to_sym)) ? params[:size].to_sym : :byte
+      content_type :json
+      if params[:size]
+        size = params[:size] ? params[:size].to_sym : nil
+        log_halt 400, "size parameter must be of: #{DiskUsage::SIZE.keys.join(',')}" unless DiskUsage::SIZE.include?(size)
+      else
+        size = :byte
+      end
+
       monitor_dirs = Hash[::PulpProxy::Pulp3Plugin.settings.marshal_dump.select { |key, _| key == :pulp_dir || key == :pulp_content_dir }]
       begin
-        pulp_disk = DiskUsage.new({:path => monitor_dirs, :size => size})
+        pulp_disk = DiskUsage.new({:path => monitor_dirs, :size => size.to_sym})
         pulp_disk.to_json
       rescue ::Proxy::Error::ConfigurationError
         log_halt 500, 'Could not find df command to evaluate disk space'

--- a/lib/smart_proxy_pulp_plugin/pulp3_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_client.rb
@@ -4,17 +4,22 @@ require 'uri'
 require 'smart_proxy_pulp_plugin/settings'
 
 module PulpProxy
-  class PulpClient
+  class Pulp3Client
     def self.get(path)
-      uri = URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s)
+      uri = URI.parse(::PulpProxy::Pulp3Plugin.settings.pulp_url.to_s)
       req = Net::HTTP::Get.new(URI.join(uri.to_s.chomp('/') + '/', path))
       req.add_field('Accept', 'application/json')
       req.content_type = 'application/json'
-      response = self.http.request(req)
+      self.http.request(req)
+    end
+
+    def self.capabilities
+      body = JSON.parse(get("api/v3/status/").body)
+      body['versions'].map{|item| item['component'] }
     end
 
     def self.http
-      uri = URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s)
+      uri = URI.parse(::PulpProxy::Pulp3Plugin.settings.pulp_url.to_s)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/smart_proxy_pulp_plugin/pulp3_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_client.rb
@@ -29,7 +29,6 @@ module PulpProxy
       uri = URI.parse(::PulpProxy::Pulp3Plugin.settings.pulp_url.to_s)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       http
     end
   end

--- a/lib/smart_proxy_pulp_plugin/pulp3_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_client.rb
@@ -16,6 +16,8 @@ module PulpProxy
     def self.capabilities
       body = JSON.parse(get("api/v3/status/").body)
       body['versions'].map{|item| item['component'] }
+    rescue => e
+      []
     end
 
     def self.http

--- a/lib/smart_proxy_pulp_plugin/pulp3_http_config.ru
+++ b/lib/smart_proxy_pulp_plugin/pulp3_http_config.ru
@@ -1,0 +1,5 @@
+require 'smart_proxy_pulp_plugin/pulp3_api'
+
+map "/pulp3" do
+  run PulpProxy::Pulp3Api
+end

--- a/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
@@ -1,3 +1,5 @@
+require 'puppet_proxy_common/custom_validators'
+
 module PulpProxy
   class Pulp3Plugin < ::Proxy::Plugin
     plugin "pulp3", ::PulpProxy::VERSION
@@ -5,6 +7,9 @@ module PulpProxy
                      :pulp_dir => '/var/lib/pulp',
                      :pulp_content_dir => '/var/lib/pulp/content',
                      :mirror => false
+
+    load_validators :url => ::Proxy::Puppet::Validators::UrlValidator
+    validate :pulp_url, :url => true
 
     expose_setting :pulp_url
     expose_setting :mirror

--- a/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
@@ -1,0 +1,21 @@
+module PulpProxy
+  class Pulp3Plugin < ::Proxy::Plugin
+    plugin "pulp3", ::PulpProxy::VERSION
+    default_settings :pulp_url => 'https://localhost/pulp/',
+                     :pulp_dir => '/var/lib/pulp',
+                     :pulp_content_dir => '/var/lib/pulp/content',
+                     :mongodb_dir => '/var/lib/mongodb',
+                     :mirror => false
+
+    expose_setting :pulp_url
+    expose_setting :mirror
+    capability( lambda do ||
+      begin
+        Pulp3Client.capabilities
+      rescue => e
+      end
+    end)
+    http_rackup_path File.expand_path("pulp3_http_config.ru", File.expand_path("../", __FILE__))
+    https_rackup_path File.expand_path("pulp3_http_config.ru", File.expand_path("../", __FILE__))
+  end
+end

--- a/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
@@ -4,16 +4,12 @@ module PulpProxy
     default_settings :pulp_url => 'https://localhost/pulp/',
                      :pulp_dir => '/var/lib/pulp',
                      :pulp_content_dir => '/var/lib/pulp/content',
-                     :mongodb_dir => '/var/lib/mongodb',
                      :mirror => false
 
     expose_setting :pulp_url
     expose_setting :mirror
     capability( lambda do ||
-      begin
-        Pulp3Client.capabilities
-      rescue => e
-      end
+      Pulp3Client.capabilities
     end)
     http_rackup_path File.expand_path("pulp3_http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("pulp3_http_config.ru", File.expand_path("../", __FILE__))

--- a/lib/smart_proxy_pulp_plugin/pulp_node_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_node_plugin.rb
@@ -7,6 +7,7 @@ module PulpNodeProxy
                      :puppet_content_dir => '/etc/puppet/environments',
                      :mongodb_dir => '/var/lib/mongodb'
 
+    expose_setting :pulp_url
     http_rackup_path File.expand_path("pulp_node_http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("pulp_node_http_config.ru", File.expand_path("../", __FILE__))
   end

--- a/lib/smart_proxy_pulp_plugin/pulp_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_plugin.rb
@@ -7,6 +7,8 @@ module PulpProxy
                      :puppet_content_dir => '/etc/puppet/environments',
                      :mongodb_dir => '/var/lib/mongodb'
 
+    expose_setting :pulp_url
+
     http_rackup_path File.expand_path("pulp_http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("pulp_http_config.ru", File.expand_path("../", __FILE__))
   end

--- a/settings.d/pulp3.yml.example
+++ b/settings.d/pulp3.yml.example
@@ -1,9 +1,7 @@
 ---
 :enabled: true
 #:pulp_url: https://localhost/pulp/
-# Path to pulp, pulp content and mongodb directories
 #:pulp_dir: /var/lib/pulp
 #:pulp_content_dir: /var/lib/pulp/content
 #:puppet_content_dir: /etc/pupppet/environments
-#:mongodb_dir: /var/lib/mongodb
 #:mirror: false

--- a/settings.d/pulp3.yml.example
+++ b/settings.d/pulp3.yml.example
@@ -1,0 +1,9 @@
+---
+:enabled: true
+#:pulp_url: https://localhost/pulp/
+# Path to pulp, pulp content and mongodb directories
+#:pulp_dir: /var/lib/pulp
+#:pulp_content_dir: /var/lib/pulp/content
+#:puppet_content_dir: /etc/pupppet/environments
+#:mongodb_dir: /var/lib/mongodb
+#:mirror: false

--- a/test/pulp3_api_test.rb
+++ b/test/pulp3_api_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+require 'webmock/test_unit'
+require 'mocha/test_unit'
+require 'rack/test'
+
+require 'smart_proxy_pulp_plugin/pulp3_plugin'
+require 'smart_proxy_pulp_plugin/pulp3_api'
+
+class Pulp3ApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    PulpProxy::Pulp3Api.new
+  end
+
+  def test_returns_pulp_status_on_200
+    stub_request(:get, "#{::PulpProxy::Pulp3Plugin.settings.pulp_url.to_s}api/v3/status/").to_return(:body => "{\"api_version\":\"3\"}")
+    get '/status'
+
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    assert_equal("{\"api_version\":\"3\"}", last_response.body)
+  end
+
+  def test_returns_50X_on_connection_refused
+    Net::HTTP.any_instance.expects(:request).raises(Errno::ECONNREFUSED)
+    get '/status'
+    assert last_response.server_error?
+  ensure
+    Net::HTTP.any_instance.unstub(:request)
+  end
+
+  def test_returns_50X_on_socket_error
+    Net::HTTP.any_instance.expects(:request).raises(SocketError)
+    get '/status'
+    assert last_response.server_error?
+  ensure
+    Net::HTTP.any_instance.unstub(:request)
+  end
+
+  def test_returns_pulp_disk_on_200
+    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
+                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
+                                         :mongodb_dir => ::Sinatra::Application.settings.root)
+    get '/status/disk_usage'
+    response = JSON.parse(last_response.body)
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    assert_equal(%w(filesystem 1-blocks used available percent mounted path size).to_set, response['pulp_dir'].keys.to_set)
+  end
+
+  def test_change_pulp_disk_size
+    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
+                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
+                                         :mongodb_dir => ::Sinatra::Application.settings.root)
+    get '/status/disk_usage?size=megabyte'
+    response = JSON.parse(last_response.body)
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    assert_equal('megabyte', response['pulp_dir']['size'])
+  end
+
+  def test_default_pulp_disk_size
+    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
+                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
+                                         :mongodb_dir => ::Sinatra::Application.settings.root)
+    get '/status/disk_usage?size=pitabyte'
+    response = JSON.parse(last_response.body)
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    assert_equal('byte', response['pulp_dir']['size'])
+  end
+end

--- a/test/pulp3_api_test.rb
+++ b/test/pulp3_api_test.rb
@@ -57,13 +57,11 @@ class Pulp3ApiTest < Test::Unit::TestCase
     assert_equal('megabyte', response['pulp_dir']['size'])
   end
 
-  def test_default_pulp_disk_size
+  def test_pulp_disk_bad_size
     PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
                                          :pulp_content_dir => ::Sinatra::Application.settings.root,
                                          :mongodb_dir => ::Sinatra::Application.settings.root)
     get '/status/disk_usage?size=pitabyte'
-    response = JSON.parse(last_response.body)
-    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
-    assert_equal('byte', response['pulp_dir']['size'])
+    assert_equal 400, last_response.status
   end
 end

--- a/test/pulp3_client_test.rb
+++ b/test/pulp3_client_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'webmock/test_unit'
+require 'mocha/test_unit'
+
+require 'smart_proxy_pulp_plugin/pulp3_plugin'
+require 'smart_proxy_pulp_plugin/pulp3_client'
+
+class Pulp3ClientTest < Test::Unit::TestCase
+  def test_get_status_with_trailing_slash
+    PulpProxy::Pulp3Plugin.load_test_settings('pulp_url' => 'http://localhost/pulp/')
+    stub_request(:get, "http://localhost/pulp/api/v3/status/")
+
+    result = PulpProxy::Pulp3Client.get("api/v3/status/")
+    assert result.is_a?(Net::HTTPSuccess)
+  end
+
+  def test_get_status_without_trailing_slash
+    PulpProxy::Pulp3Plugin.load_test_settings('pulp_url' => 'http://localhost/pulp')
+    stub_request(:get, "http://localhost/pulp/api/v3/status/")
+
+    result = PulpProxy::Pulp3Client.get("api/v3/status/")
+    assert result.is_a?(Net::HTTPSuccess)
+  end
+
+  def test_get_capabilities
+    capabilities = {'versions' => [{'component' => 'foo', 'version' => '1.0'}]}
+    PulpProxy::Pulp3Plugin.load_test_settings('pulp_url' => 'http://localhost/pulp/')
+    stub_request(:get, "http://localhost/pulp/api/v3/status/").to_return(:body => capabilities.to_json)
+
+    assert_equal ['foo'], PulpProxy::Pulp3Client.capabilities
+  end
+end


### PR DESCRIPTION
This does a few things:
* expose pulp_url as a setting on pulp and pulp_node
* fixes a bug that prevents the smart proxy pulp2 from talking to external urls
* adds a pulp3 plugin exposing the pulp url and running pulp3 plugins as capabilities