### PR TITLE
creation of README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,7 +7,7 @@ While this plugin is part of the Foreman project it can only be used with Katell
 
 The Foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
 The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-pulp" option.
-Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/latest/index.html#4.3.1SmartProxyInstallation
+Documentation can be found here for how to install a stand alone smart proxy https://theforeman.org/manuals/latest/index.html#4.3.1SmartProxyInstallation
 
 ### Prerequisites
 

--- a/README.MD
+++ b/README.MD
@@ -11,9 +11,9 @@ Documentation can be found here for how to install a stand alone smart proxy htt
 
 ### Prerequisites
 
-A working Katello instance (note not Foreman - must be Katello)
-A smart proxy or capsule with the Pulp plugin installed and enabled
-A Pulp installation as part of the Katello install, or a remote Pulp service to connect to
+* working Katello instance (note not Foreman - must be Katello)
+* smart proxy or capsule with the Pulp plugin installed and enabled
+* Pulp installation as part of the Katello install, or a remote Pulp service to connect to
 
 
 ### Installing

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,68 @@
+#  Foreman Smart Proxy Pulp
+
+Foreman project Smart Proxy plugin for pulp allowing Katello hosts to interact with pulp application services for content management
+While this plugin is part of the foreman project it can only be used with Katello as Foreman is not content aware without the Katello plugin.
+
+## Getting Started
+
+The foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
+The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-pulp" option.
+Documentation can be found here for how to install a stand alone smart proxy https://theforeman.org/manuals/$current_foreman_version/index.html#4.3.1SmartProxyInstallation
+
+### Prerequisites
+
+A working Katello instance (note not foreman - must be Katello)
+A smart proxy or capsule with the pulp plugin installed and enabled
+A pulp installation as part of the katello install, or a remote pulp service to connect to
+
+
+### Installing
+
+Assuming prerequisites are met, the pulp plugin must be enabled in the foreman-proxy directory with the pulp.yaml and pulpnode.yaml
+the following parameters are required to be set
+
+```
+---
+# Pulp integration
+:enabled: true
+:pulp_url: https://url-to-pulp-service
+# Path to pulp, pulp content and mongodb directories
+:pulp_dir: directory for pulp on the pulp node
+:pulp_content_dir: where the pulp content is held
+:puppet_content_dir: where the puppet modules are held
+:mongodb_dir: the mongodb datadir for pulp
+
+```
+
+for example
+
+```
+---
+# Pulp integration
+:enabled: true
+:pulp_url: https://pulp.somedomain.com (note katello installs are normally https://katelloname.somedomain.com/pulp)
+# Path to pulp, pulp content and mongodb directories
+:pulp_dir: /var/lib/pulp
+:pulp_content_dir: /var/lib/pulp/content
+:puppet_content_dir: /etc/puppetlabs/code/environments
+:mongodb_dir: /var/lib/mongodb
+
+```
+
+## Running the tests
+Give some test cases - todo
+
+
+
+## Authors
+
+* **Matt Darcy** - *Initial Draft* - [ikonia](https://github.com/ikonia)
+
+
+## License
+
+This project is licensed under the GNU General Public License v3.0 - see the [LICENSE.md](LICENSE.md) file for details
+
+## Acknowledgments
+
+* Foreman IRC user areyus who prompted the need for this README

--- a/README.MD
+++ b/README.MD
@@ -23,6 +23,7 @@ the following parameters are required to be set
 
 ```
 ---
+```yaml
 # Pulp integration
 :enabled: true
 :pulp_url: https://url-to-pulp-service

--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ for example
 
 ## Running the tests
 
-Todo - so test examples
+Todo - some test examples
 
 
 ## Authors

--- a/README.MD
+++ b/README.MD
@@ -7,7 +7,7 @@ While this plugin is part of the Foreman project it can only be used with Katell
 
 The Foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
 The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-Pulp" option.
-Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/$current_foreman_version/index.html#4.3.1SmartProxyInstallation
+Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/latest/index.html#4.3.1SmartProxyInstallation
 
 ### Prerequisites
 
@@ -18,7 +18,7 @@ A Pulp installation as part of the Katello install, or a remote Pulp service to 
 
 ### Installing
 
-Assuming prerequisites are met, the Pulp plugin must be enabled in the Foreman-proxy directory with the Pulp.yaml and Pulpnode.yaml
+Assuming prerequisites are met, the Pulp plugin must be enabled in the Foreman-proxy directory with the pulp.yaml and pulpnode.yaml
 the following parameters are required to be set
 
 ```
@@ -56,7 +56,7 @@ Todo - some test examples
 
 ## Authors
 
-* **Matt Darcy** - *Initial Draft* - [ikonia](https://github.com/ikonia)
+* **The Foreman Project** - *Initial Draft* - https://www.theforeman.org/
 
 
 ## License

--- a/README.MD
+++ b/README.MD
@@ -1,24 +1,24 @@
-#  Foreman Smart Proxy Pulp
+#  Foreman Pulp Plugin
 
-Foreman project Smart Proxy plugin for pulp allowing Katello hosts to interact with pulp application services for content management
-While this plugin is part of the foreman project it can only be used with Katello as Foreman is not content aware without the Katello plugin.
+Foreman project plugin for Pulp allowing Katello hosts to interact with Pulp application services for content management
+While this plugin is part of the Foreman project it can only be used with Katello as Foreman is not content aware without the Katello plugin.
 
 ## Getting Started
 
-The foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
-The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-pulp" option.
-Documentation can be found here for how to install a stand alone smart proxy https://theforeman.org/manuals/$current_foreman_version/index.html#4.3.1SmartProxyInstallation
+The Foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
+The plugin can also be installed as part of the Foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-Pulp" option.
+Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/$current_foreman_version/index.html#4.3.1SmartProxyInstallation
 
 ### Prerequisites
 
-A working Katello instance (note not foreman - must be Katello)
-A smart proxy or capsule with the pulp plugin installed and enabled
-A pulp installation as part of the katello install, or a remote pulp service to connect to
+A working Katello instance (note not Foreman - must be Katello)
+A smart proxy or capsule with the Pulp plugin installed and enabled
+A Pulp installation as part of the Katello install, or a remote Pulp service to connect to
 
 
 ### Installing
 
-Assuming prerequisites are met, the pulp plugin must be enabled in the foreman-proxy directory with the pulp.yaml and pulpnode.yaml
+Assuming prerequisites are met, the Pulp plugin must be enabled in the Foreman-proxy directory with the Pulp.yaml and Pulpnode.yaml
 the following parameters are required to be set
 
 ```
@@ -26,11 +26,11 @@ the following parameters are required to be set
 # Pulp integration
 :enabled: true
 :pulp_url: https://url-to-pulp-service
-# Path to pulp, pulp content and mongodb directories
-:pulp_dir: directory for pulp on the pulp node
-:pulp_content_dir: where the pulp content is held
+# Path to Pulp, Pulp content and mongodb directories
+:pulp_dir: directory for Pulp on the Pulp node
+:pulp_content_dir: where the Pulp content is held
 :puppet_content_dir: where the puppet modules are held
-:mongodb_dir: the mongodb datadir for pulp
+:mongodb_dir: the mongodb datadir for Pulp
 
 ```
 
@@ -40,8 +40,8 @@ for example
 ---
 # Pulp integration
 :enabled: true
-:pulp_url: https://pulp.somedomain.com (note katello installs are normally https://katelloname.somedomain.com/pulp)
-# Path to pulp, pulp content and mongodb directories
+:pulp_url: https://pulp.somedomain.com (note Katello installs are normally https://katelloname.somedomain.com/pulp)
+# Path to Pulp, Pulp content and mongodb directories
 :pulp_dir: /var/lib/pulp
 :pulp_content_dir: /var/lib/pulp/content
 :puppet_content_dir: /etc/puppetlabs/code/environments
@@ -50,8 +50,8 @@ for example
 ```
 
 ## Running the tests
-Give some test cases - todo
 
+Todo - so test examples
 
 
 ## Authors

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ While this plugin is part of the Foreman project it can only be used with Katell
 ## Getting Started
 
 The Foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
-The plugin can also be installed as part of the Foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-Pulp" option.
+The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-Pulp" option.
 Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/$current_foreman_version/index.html#4.3.1SmartProxyInstallation
 
 ### Prerequisites

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ While this plugin is part of the Foreman project it can only be used with Katell
 ## Getting Started
 
 The Foreman project provides documentation on this specific plugin installation from multiple methods, distribution specific RPM, distribution specific DEB and direct manual build from source. 
-The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-Pulp" option.
+The plugin can also be installed as part of the foreman-installer puppet class with the "--[no-]enable-foreman-proxy-plugin-pulp" option.
 Documentation can be found here for how to install a stand alone smart proxy https://theForeman.org/manuals/latest/index.html#4.3.1SmartProxyInstallation
 
 ### Prerequisites

--- a/README.MD
+++ b/README.MD
@@ -21,9 +21,9 @@ A Pulp installation as part of the Katello install, or a remote Pulp service to 
 Assuming prerequisites are met, the Pulp plugin must be enabled in the Foreman-proxy directory with the pulp.yaml and pulpnode.yaml
 the following parameters are required to be set
 
-```
----
 ```yaml
+
+---
 # Pulp integration
 :enabled: true
 :pulp_url: https://url-to-pulp-service
@@ -37,7 +37,8 @@ the following parameters are required to be set
 
 for example
 
-```
+```yaml
+
 ---
 # Pulp integration
 :enabled: true

--- a/README.md
+++ b/README.md
@@ -22,33 +22,29 @@ Assuming prerequisites are met, the Pulp plugin must be enabled in the Foreman-p
 the following parameters are required to be set
 
 ```yaml
-
 ---
 # Pulp integration
 :enabled: true
-:pulp_url: https://url-to-pulp-service
+:pulp_url: https://url-to-pulp-service.example.com
 # Path to Pulp, Pulp content and mongodb directories
 :pulp_dir: directory for Pulp on the Pulp node
 :pulp_content_dir: where the Pulp content is held
 :puppet_content_dir: where the puppet modules are held
 :mongodb_dir: the mongodb datadir for Pulp
-
 ```
 
 for example
 
 ```yaml
-
 ---
 # Pulp integration
 :enabled: true
-:pulp_url: https://pulp.somedomain.com (note Katello installs are normally https://katelloname.somedomain.com/pulp)
+:pulp_url: https://pulp.somedomain.com # (note Katello installs are normally https://katelloname.somedomain.com/pulp)
 # Path to Pulp, Pulp content and mongodb directories
 :pulp_dir: /var/lib/pulp
 :pulp_content_dir: /var/lib/pulp/content
 :puppet_content_dir: /etc/puppetlabs/code/environments
 :mongodb_dir: /var/lib/mongodb
-
 ```
 
 ## Running the tests
@@ -58,8 +54,7 @@ Todo - some test examples
 
 ## Authors
 
-* **The Foreman Project** - *Initial Draft* - https://www.theforeman.org/
-
+* **The Foreman Project** - *Initial Draft* - https://theforeman.org/
 
 ## License
 


### PR DESCRIPTION
after having a minor problem using the pulp plugin with foreman on a remote pulp host I realised the functionality I was working on was never going to work / supported. This could have been mitigated with a basic README type document in the repo to give some basic overview. This is a first draft that can be expanded on by people, but it provides some base coverage, dependencies and config example.