### PR TITLE
Add a registry_url to expose

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
@@ -4,15 +4,18 @@ module PulpProxy
   class Pulp3Plugin < ::Proxy::Plugin
     plugin "pulp3", ::PulpProxy::VERSION
     default_settings :pulp_url => 'https://localhost/pulp/',
+                     :content_app_url => 'https://localhost:24816/',
                      :pulp_dir => '/var/lib/pulp',
                      :pulp_content_dir => '/var/lib/pulp/content',
                      :mirror => false
 
     load_validators :url => ::PulpProxy::Validators::PulpUrlValidator
     validate :pulp_url, :url => true
+    validate :content_app_url, :url => true
 
     expose_setting :pulp_url
     expose_setting :mirror
+    expose_setting :content_app_url
     capability( lambda do ||
       Pulp3Client.capabilities
     end)

--- a/settings.d/pulp3.yml.example
+++ b/settings.d/pulp3.yml.example
@@ -1,6 +1,7 @@
 ---
 :enabled: true
 #:pulp_url: https://localhost/pulp/
+#:content_app_url: https://localhost:24816/
 #:pulp_dir: /var/lib/pulp
 #:pulp_content_dir: /var/lib/pulp/content
 #:mirror: false

--- a/test/pulp3_plugin_integration_test.rb
+++ b/test/pulp3_plugin_integration_test.rb
@@ -15,7 +15,7 @@ class Pulp3FeaturesTest < Test::Unit::TestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulp.yml').returns(enabled: true, pulp_url: 'http://pulp.example.com/foo')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpnode.yml').returns(enabled: true, pulp_url: 'http://pulpnode.example.com/foo')
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulp3.yml').returns(enabled: true, pulp_url: 'http://pulp3.example.com/foo')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulp3.yml').returns(enabled: true, pulp_url: 'http://pulp3.example.com/foo', content_app_url: 'http://pulp3.example.com:24816/')
     PulpProxy::Pulp3Client.stubs(:capabilities).returns(['foo'])
 
     get '/features'
@@ -24,7 +24,11 @@ class Pulp3FeaturesTest < Test::Unit::TestCase
 
     assert_equal 'running', pulp3['state']
 
-    expected_settings = {'pulp_url' => 'http://pulp3.example.com/foo', 'mirror' => false}
+    expected_settings = {
+      'pulp_url' => 'http://pulp3.example.com/foo',
+      'content_app_url' => 'http://pulp3.example.com:24816/',
+      'mirror' => false
+    }
     assert_equal(expected_settings, pulp3['settings'])
     assert_equal(['foo'], pulp3['capabilities'])
   end


### PR DESCRIPTION
This allows Katello to autodetect the container registry URL.