### PR TITLE
Drop Pulp v3 disk usage

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp3_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_api.rb
@@ -16,23 +16,5 @@ module PulpProxy
         log_halt 503, "Communication error with '#{URI.parse(::PulpProxy::Settings.settings.pulp_url.to_s).host}': #{e.message}"
       end
     end
-
-    get '/status/disk_usage' do
-      content_type :json
-      if params[:size]
-        size = params[:size] ? params[:size].to_sym : nil
-        log_halt 400, "size parameter must be of: #{DiskUsage::SIZE.keys.join(',')}" unless DiskUsage::SIZE.include?(size)
-      else
-        size = :byte
-      end
-
-      monitor_dirs = Hash[::PulpProxy::Pulp3Plugin.settings.marshal_dump.select { |key, _| key == :pulp_dir || key == :pulp_content_dir }]
-      begin
-        pulp_disk = DiskUsage.new({:path => monitor_dirs, :size => size.to_sym})
-        pulp_disk.to_json
-      rescue ::Proxy::Error::ConfigurationError
-        log_halt 500, 'Could not find df command to evaluate disk space'
-      end
-    end
   end
 end

--- a/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp3_plugin.rb
@@ -5,8 +5,6 @@ module PulpProxy
     plugin "pulp3", ::PulpProxy::VERSION
     default_settings :pulp_url => 'https://localhost',
                      :content_app_url => 'https://localhost:24816/',
-                     :pulp_dir => '/var/lib/pulp',
-                     :pulp_content_dir => '/var/lib/pulp/content',
                      :mirror => false
 
     load_validators :url => ::PulpProxy::Validators::PulpUrlValidator

--- a/settings.d/pulp3.yml.example
+++ b/settings.d/pulp3.yml.example
@@ -2,6 +2,4 @@
 :enabled: true
 #:pulp_url: https://localhost/
 #:content_app_url: https://localhost:24816/
-#:pulp_dir: /var/lib/pulp
-#:pulp_content_dir: /var/lib/pulp/content
 #:mirror: false

--- a/test/pulp3_api_test.rb
+++ b/test/pulp3_api_test.rb
@@ -14,6 +14,7 @@ class Pulp3ApiTest < Test::Unit::TestCase
   end
 
   def test_returns_pulp_status_on_200
+    PulpProxy::Pulp3Plugin.load_test_settings({})
     stub_request(:get, "#{::PulpProxy::Pulp3Plugin.settings.pulp_url.to_s}/pulp/api/v3/status/").to_return(:body => "{\"api_version\":\"3\"}")
     get '/status'
 
@@ -35,33 +36,5 @@ class Pulp3ApiTest < Test::Unit::TestCase
     assert last_response.server_error?
   ensure
     Net::HTTP.any_instance.unstub(:request)
-  end
-
-  def test_returns_pulp_disk_on_200
-    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
-                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
-                                         :mongodb_dir => ::Sinatra::Application.settings.root)
-    get '/status/disk_usage'
-    response = JSON.parse(last_response.body)
-    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
-    assert_equal(%w(filesystem 1-blocks used available percent mounted path size).to_set, response['pulp_dir'].keys.to_set)
-  end
-
-  def test_change_pulp_disk_size
-    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
-                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
-                                         :mongodb_dir => ::Sinatra::Application.settings.root)
-    get '/status/disk_usage?size=megabyte'
-    response = JSON.parse(last_response.body)
-    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
-    assert_equal('megabyte', response['pulp_dir']['size'])
-  end
-
-  def test_pulp_disk_bad_size
-    PulpProxy::Pulp3Plugin.load_test_settings(:pulp_dir => ::Sinatra::Application.settings.root,
-                                         :pulp_content_dir => ::Sinatra::Application.settings.root,
-                                         :mongodb_dir => ::Sinatra::Application.settings.root)
-    get '/status/disk_usage?size=pitabyte'
-    assert_equal 400, last_response.status
   end
 end


### PR DESCRIPTION
The Pulp 3 status API now has this information. By dropping it, we make sure that the proper API is used. The added benefit is that there is no longer the need to host the proxy on the same box or apply ugly hacks like a shared filesystem.