### PR TITLE
Fixes #29449 - add credentials for pulpcore

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -14,6 +14,8 @@ module PulpProxy
     expose_setting :pulp_url
     expose_setting :mirror
     expose_setting :content_app_url
+    expose_setting :username
+    expose_setting :password
     capability( lambda do ||
       PulpcoreClient.capabilities
     end)

--- a/settings.d/pulpcore.yml.example
+++ b/settings.d/pulpcore.yml.example
@@ -2,4 +2,6 @@
 :enabled: true
 #:pulp_url: https://localhost/
 #:content_app_url: https://localhost:24816/
+#:username: admin
+#:password: password
 #:mirror: false

--- a/test/pulpcore_plugin_integration_test.rb
+++ b/test/pulpcore_plugin_integration_test.rb
@@ -27,6 +27,37 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     expected_settings = {
       'pulp_url' => 'http://pulpcore.example.com/foo',
       'content_app_url' => 'http://pulpcore.example.com:24816/',
+      'username' => nil,
+      'password' => nil,
+      'mirror' => false
+    }
+    assert_equal(expected_settings, pulpcore['settings'])
+    assert_equal(['foo'], pulpcore['capabilities'])
+  end
+
+  def test_features_with_optional_params
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulp.yml').returns(enabled: true, pulp_url: 'http://pulp.example.com/foo')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpnode.yml').returns(enabled: true, pulp_url: 'http://pulpnode.example.com/foo')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(
+      enabled: true,
+      pulp_url: 'http://pulpcore.example.com/foo',
+      content_app_url: 'http://pulpcore.example.com:24816/',
+      username: 'admin',
+      password: 'password'
+    )
+    PulpProxy::PulpcoreClient.stubs(:capabilities).returns(['foo'])
+
+    get '/features'
+    response = JSON.parse(last_response.body)
+    pulpcore = response['pulpcore']
+
+    assert_equal 'running', pulpcore['state']
+
+    expected_settings = {
+      'pulp_url' => 'http://pulpcore.example.com/foo',
+      'content_app_url' => 'http://pulpcore.example.com:24816/',
+      'username' => 'admin',
+      'password' => 'password',
       'mirror' => false
     }
     assert_equal(expected_settings, pulpcore['settings'])


### PR DESCRIPTION
Relates to https://github.com/Katello/katello/pull/8640