### PR TITLE
Add setting client_authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The following parameters should be set:
 #:mirror: false
 ```
 
+### Settings
+
+#### client_authentication
+
+The setting client_authentication is an array of authentication types supported by the Pulp installation. The valid values are:
+
+ * password: username and password authentication
+ * client_certificate: This indicates whether the service handling authentication for Pulp allows matching the client certificates presented common name to some paired string, often hostname, and setting the remote user header.
+ * client_certificate_admin_only: This indicates the service handling authentication for Pulp allows matching only client certificates where the common name is set to 'admin'.
+
 ## Running the tests
 
 Run all tests

--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -1,18 +1,27 @@
+require 'smart_proxy_pulp_plugin/validators'
+
 module PulpProxy
   class PulpcorePlugin < ::Proxy::Plugin
     plugin "pulpcore", ::PulpProxy::VERSION
     default_settings :pulp_url => 'https://localhost',
                      :content_app_url => 'https://localhost:24816/',
-                     :mirror => false
+                     :mirror => false,
+                     :client_authentication => ['password', 'client_certificate']
 
+    AUTH_TYPES = ['password', 'client_certificate', 'client_certificate_admin_only'].freeze
+
+    load_validators include: ::PulpProxy::Validators::Include
     validate :pulp_url, :url => true
     validate :content_app_url, :url => true
+    validate :client_authentication, :include => AUTH_TYPES
 
     expose_setting :pulp_url
     expose_setting :mirror
     expose_setting :content_app_url
     expose_setting :username
     expose_setting :password
+    expose_setting :client_authentication
+
     capability -> { PulpcoreClient.capabilities }
     rackup_path File.expand_path('pulpcore_http_config.ru', __dir__)
   end

--- a/lib/smart_proxy_pulp_plugin/validators.rb
+++ b/lib/smart_proxy_pulp_plugin/validators.rb
@@ -1,0 +1,15 @@
+module PulpProxy
+  module Validators
+    class Include < ::Proxy::PluginValidators::Base
+      def validate!(settings)
+        setting_value = settings[@setting_name]
+
+        unless (setting_value - @params).empty?
+          raise ::Proxy::Error::ConfigurationError, "Parameter '#{@setting_name}' is expected to be one or more of #{@params}"
+        else
+          true
+        end
+      end
+    end
+  end
+end

--- a/settings.d/pulpcore.yml.example
+++ b/settings.d/pulpcore.yml.example
@@ -5,3 +5,4 @@
 #:username: admin
 #:password: password
 #:mirror: false
+#:client_authentication: ['password', 'client_certificate']

--- a/test/pulpcore_plugin_integration_test.rb
+++ b/test/pulpcore_plugin_integration_test.rb
@@ -30,7 +30,8 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
       'content_app_url' => 'http://pulpcore.example.com:24816/',
       'username' => nil,
       'password' => nil,
-      'mirror' => false
+      'mirror' => false,
+      'client_authentication' => ['password', 'client_certificate']
     }
     assert_equal(expected_settings, pulpcore['settings'])
     assert_equal(['foo'], pulpcore['capabilities'])
@@ -58,7 +59,8 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
       'content_app_url' => 'http://pulpcore.example.com:24816/',
       'username' => 'admin',
       'password' => 'password',
-      'mirror' => false
+      'mirror' => false,
+      'client_authentication' => ['password', 'client_certificate']
     }
     assert_equal(expected_settings, pulpcore['settings'])
     assert_equal(['foo'], pulpcore['capabilities'])
@@ -90,5 +92,19 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
 
     assert_equal 'failed', pulpcore['state'], failure
     assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'content_app_url' is expected to have a non-empty value", failure
+  end
+
+  def test_invalid_client_authentication
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(enabled: true, client_authentication: ['fake_auth_type'])
+
+    get '/features'
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    response = JSON.parse(last_response.body)
+    pulpcore = response['pulpcore']
+
+    failure = Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:pulpcore]
+
+    assert_equal 'failed', pulpcore['state'], failure
+    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'client_authentication' is expected to be one or more of [\"password\", \"client_certificate\", \"client_certificate_admin_only\"]", failure
   end
 end


### PR DESCRIPTION
This setting indicates whether the service handling authenication to
Pulp, for example Apache, is configured to allow parsing the common
name from the supplied certificate, matching it to hostname and then
setting the remote user header to be sent down to Pulp.