### PR TITLE
Expose the container registry URL

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -4,6 +4,7 @@ module PulpProxy
   class PulpcorePlugin < ::Proxy::Plugin
     plugin "pulpcore", ::PulpProxy::VERSION
     default_settings :pulp_url => 'https://localhost',
+                     :container_registry_url => false,
                      :content_app_url => 'https://localhost:24816/',
                      :mirror => false,
                      :client_authentication => ['password', 'client_certificate']
@@ -15,9 +16,16 @@ module PulpProxy
     validate :content_app_url, :url => true
     validate :client_authentication, :include => AUTH_TYPES
 
+    load_programmable_settings do |setting|
+      if settings[:container_registry_url] == true
+        settings[:container_registry_url] = URI.join(settings[:pulp_url], '/pulpcore_registry')
+      end
+    end
+
     expose_setting :pulp_url
     expose_setting :mirror
     expose_setting :content_app_url
+    expose_setting :container_registry_url
     expose_setting :username
     expose_setting :password
     expose_setting :client_authentication

--- a/settings.d/pulpcore.yml.example
+++ b/settings.d/pulpcore.yml.example
@@ -1,8 +1,22 @@
 ---
 :enabled: true
-#:pulp_url: https://localhost/
-#:content_app_url: https://localhost:24816/
+
+# The URL serving the pulpcore-api without any path
+#:pulp_url: https://localhost:24817/
+# Only set this if the container registry is present. This points to pulpcore-api.
+# Can also be set to true in which case it'll be derived from pulp_url
+#:container_registry_url: https://localhost:24817/pulpcore_registry
+# The content URL. This points to pulpcore-content
+#:content_app_url: https://localhost:24816/pulp/content
+
+# Expose which client authentication works. At least one is needed.
+# client_certificate and client_certificate_admin_only are mutually exclusive
+# Possible values
+#:client_authentication: ['password', 'client_certificate', 'client_certificate_admin_only']
+
+# Not needed in most production setups
 #:username: admin
 #:password: password
+
+# False implies it's a primary. There should only be one primary in your infra
 #:mirror: false
-#:client_authentication: ['password', 'client_certificate']


### PR DESCRIPTION
Today Katello constructs this URL, but we're in a far better position to determine this. The installer can also explicitly set this since it already knows it.

It also expands the sample config to further document what the settings are and how to use them. While not used in production by us (the installer overwrites it), it is helpful to provide context.

This still needs some tests.