### PR TITLE
Fixes #33670 - remove credentials for pulpcore

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -20,8 +20,6 @@ module PulpProxy
     expose_setting :pulp_url
     expose_setting :mirror
     expose_setting :content_app_url
-    expose_setting :username
-    expose_setting :password
     expose_setting :client_authentication
     expose_setting :rhsm_url
 

--- a/test/pulpcore_plugin_integration_test.rb
+++ b/test/pulpcore_plugin_integration_test.rb
@@ -33,8 +33,6 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     expected_settings = {
       'pulp_url' => 'http://pulpcore.example.com/foo',
       'content_app_url' => 'http://pulpcore.example.com:24816/',
-      'username' => nil,
-      'password' => nil,
       'mirror' => false,
       'client_authentication' => ['password', 'client_certificate'],
       'rhsm_url' => 'https://rhsm.example.com/rhsm'
@@ -48,8 +46,6 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
       enabled: true,
       pulp_url: 'http://pulpcore.example.com/foo',
       content_app_url: 'http://pulpcore.example.com:24816/',
-      username: 'admin',
-      password: 'password',
       rhsm_url: 'https://rhsm.example.com/rhsm',
     )
     PulpProxy::PulpcoreClient.stubs(:capabilities).returns(['foo'])
@@ -64,8 +60,6 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     expected_settings = {
       'pulp_url' => 'http://pulpcore.example.com/foo',
       'content_app_url' => 'http://pulpcore.example.com:24816/',
-      'username' => 'admin',
-      'password' => 'password',
       'mirror' => false,
       'client_authentication' => ['password', 'client_certificate'],
       'rhsm_url' => 'https://rhsm.example.com/rhsm',


### PR DESCRIPTION
This is related to this katello PR: https://github.com/Katello/katello/pull/9892 and comes from this issue: https://projects.theforeman.org/issues/33670.

This is in support of changing how katello gets the username/password from pulp: from katello.yml instead of the smart proxy. This is so the password is not an exposed setting. I changed username too since they were both added for the same purpose.
