### PR TITLE
configure ssl_ca (if set) when using Net::HTTP

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulpcore_client.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_client.rb
@@ -27,9 +27,13 @@ module PulpProxy
     end
 
     def self.http
+      ssl_ca = ::PulpProxy::PulpcorePlugin.settings.ssl_ca ||
+               ::Proxy::SETTINGS.foreman_ssl_ca ||
+               ::Proxy::SETTINGS.ssl_ca_file
       uri = URI.parse(pulp_url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
+      http.ca_file = ssl_ca if http.use_ssl? && ssl_ca && !ssl_ca.empty?
       http
     end
 

--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -18,6 +18,7 @@ module PulpProxy
     validate :content_app_url, :url => true
     validate :client_authentication, :include => AUTH_TYPES
     validate :rhsm_url, :url => true
+    validate :ssl_ca, :file_readable => true
 
     expose_setting :pulp_url
     expose_setting :mirror

--- a/settings.d/pulpcore.yml.example
+++ b/settings.d/pulpcore.yml.example
@@ -7,3 +7,4 @@
 #:mirror: false
 #:client_authentication: ['password', 'client_certificate']
 #:rhsm_url: https://localhost/rhsm
+#:ssl_ca: /etc/ssl/certs/custom_ca.crt


### PR DESCRIPTION
Otherwise Net::HTTP can't verify SSL certs when the CA is not trusted by the system.
