### PR TITLE
drop admin_only cert type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The setting client_authentication is an array of authentication types supported 
 
  * `password`: username and password authentication
  * `client_certificate`: This indicates whether the service handling authentication for Pulp allows matching the client certificate's presented common name to some paired string, often hostname, and setting the remote user header.
- * `client_certificate_admin_only`: This indicates the service handling authentication for Pulp allows matching only client certificates where the common name is set to 'admin'.
 
 ## Running the tests
 

--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -11,7 +11,7 @@ module PulpProxy
                      :client_authentication => ['password', 'client_certificate'],
                      :rhsm_url => 'https://localhost/rhsm'
 
-    AUTH_TYPES = ['password', 'client_certificate', 'client_certificate_admin_only'].freeze
+    AUTH_TYPES = ['password', 'client_certificate'].freeze
 
     load_validators include: ::PulpProxy::Validators::Include
     validate :pulp_url, :url => true

--- a/test/pulpcore_plugin_integration_test.rb
+++ b/test/pulpcore_plugin_integration_test.rb
@@ -115,7 +115,7 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     failure = Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:pulpcore]
 
     assert_equal 'failed', pulpcore['state'], failure
-    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'client_authentication' is expected to be one or more of [\"password\", \"client_certificate\", \"client_certificate_admin_only\"]", failure
+    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'client_authentication' is expected to be one or more of [\"password\", \"client_certificate\"]", failure
   end
 
   def test_invalid_rhsm_url


### PR DESCRIPTION
This is not needed since Foreman 3.0 and not supported since 3.3.
