### PR TITLE
mark *_url settings as required and remove their default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ The following parameters should be set:
 ```yaml
 ---
 :enabled: true
-#:pulp_url: https://localhost/
-#:content_app_url: https://localhost:24816/
+:pulp_url: https://pulp.example.com/
+:content_app_url: https://pulp.example.com/pulp/content
+:rhsm_url: https://rhsm.example.com/rhsm/
 #:mirror: false
 ```
 

--- a/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
+++ b/lib/smart_proxy_pulp_plugin/pulpcore_plugin.rb
@@ -5,11 +5,8 @@ require 'smart_proxy_pulp_plugin/validators'
 module PulpProxy
   class PulpcorePlugin < ::Proxy::Plugin
     plugin "pulpcore", ::PulpProxy::VERSION
-    default_settings :pulp_url => 'https://localhost',
-                     :content_app_url => 'https://localhost:24816/',
-                     :mirror => false,
-                     :client_authentication => ['password', 'client_certificate'],
-                     :rhsm_url => 'https://localhost/rhsm'
+    default_settings :mirror => false,
+                     :client_authentication => ['password', 'client_certificate']
 
     AUTH_TYPES = ['password', 'client_certificate'].freeze
 

--- a/test/pulpcore_api_test.rb
+++ b/test/pulpcore_api_test.rb
@@ -16,8 +16,12 @@ class PulpcoreApiTest < Test::Unit::TestCase
   end
 
   def test_returns_pulp_status_on_200_ok
-    PulpProxy::PulpcorePlugin.load_test_settings({})
-    stub_request(:get, "#{::PulpProxy::PulpcorePlugin.settings.pulp_url}/pulp/api/v3/status/").to_return(:body => "{\"api_version\":\"3\"}")
+    PulpProxy::PulpcorePlugin.load_test_settings(
+      pulp_url: 'http://pulpcore.example.com/',
+      content_app_url: 'http://pulpcore.example.com/pulp/content',
+      rhsm_url: 'https://rhsm.example.com/rhsm',
+    )
+    stub_request(:get, "http://pulpcore.example.com/pulp/api/v3/status/").to_return(:body => "{\"api_version\":\"3\"}")
     get '/status'
 
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"

--- a/test/pulpcore_plugin_integration_test.rb
+++ b/test/pulpcore_plugin_integration_test.rb
@@ -8,6 +8,7 @@ require 'root/root_v2_api'
 require 'smart_proxy_pulp'
 require 'smart_proxy_pulp_plugin/pulpcore_client'
 
+# rubocop:disable Metrics/ClassLength
 class PulpcoreFeaturesTest < Test::Unit::TestCase
   include Rack::Test::Methods
 
@@ -77,7 +78,12 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
   end
 
   def test_invalid_pulp_url
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(enabled: true, pulp_url: '')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(
+      enabled: true,
+      pulp_url: '',
+      content_app_url: 'http://pulpcore.example.com:24816/',
+      rhsm_url: 'https://rhsm.example.com/rhsm',
+    )
 
     get '/features'
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -87,11 +93,16 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     failure = Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:pulpcore]
 
     assert_equal 'failed', pulpcore['state'], failure
-    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'pulp_url' is expected to have a non-empty value", failure
+    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Setting 'pulp_url' is expected to contain a url", failure
   end
 
   def test_invalid_content_app_url
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(enabled: true, content_app_url: '')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(
+      enabled: true,
+      pulp_url: 'http://pulpcore.example.com/',
+      content_app_url: '',
+      rhsm_url: 'https://rhsm.example.com/rhsm',
+    )
 
     get '/features'
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -101,11 +112,17 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     failure = Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:pulpcore]
 
     assert_equal 'failed', pulpcore['state'], failure
-    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'content_app_url' is expected to have a non-empty value", failure
+    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Setting 'content_app_url' is expected to contain a url", failure
   end
 
   def test_invalid_client_authentication
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(enabled: true, client_authentication: ['fake_auth_type'])
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(
+      enabled: true,
+      pulp_url: 'http://pulpcore.example.com/',
+      content_app_url: 'http://pulpcore.example.com/pulp/content',
+      rhsm_url: 'https://rhsm.example.com/rhsm',
+      client_authentication: ['fake_auth_type'],
+    )
 
     get '/features'
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -119,7 +136,12 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
   end
 
   def test_invalid_rhsm_url
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(enabled: true, rhsm_url: '')
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('pulpcore.yml').returns(
+      enabled: true,
+      pulp_url: 'http://pulpcore.example.com/',
+      content_app_url: 'http://pulpcore.example.com/pulp/content',
+      rhsm_url: '',
+    )
 
     get '/features'
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -129,6 +151,7 @@ class PulpcoreFeaturesTest < Test::Unit::TestCase
     failure = Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:pulpcore]
 
     assert_equal 'failed', pulpcore['state'], failure
-    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Parameter 'rhsm_url' is expected to have a non-empty value", failure
+    assert_equal "Disabling all modules in the group ['pulpcore'] due to a failure in one of them: Setting 'rhsm_url' is expected to contain a url", failure
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Those URLs are used by Katello and clients to connect to Pulp and
`localhost` is almost never the right choice here as it will be either
not reachable (for clients) or have the wrong certs (for Katello).

Guessing the right URL is hard, so let's not do that and force the user
to set it instead

